### PR TITLE
Redesign homepage with blog-style navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,427 +1,772 @@
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="pt-BR">
 <head>
-  <meta charset="UTF-8">
-  <title>Caio Marcatti - Whitepapers</title>
-  <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Caio Marcatti — Base de Conhecimento</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@500;700&display=swap" rel="stylesheet" />
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400&family=IBM+Plex+Sans:wght@300;400;500;600&family=Playfair+Display:wght@500;700&display=swap');
-
     :root {
       color-scheme: light;
-      --bg-primary: #140027;
-      --bg-secondary: #2e124f;
-      --surface: rgba(255, 255, 255, 0.08);
-      --page: #f7f2ff;
-      --text-main: #2c1144;
-      --text-muted: #5a3f7a;
-      --accent: #7b4ed8;
-      --accent-soft: #c8b4ff;
-      --shadow: 0 50px 80px rgba(20, 0, 39, 0.35);
+      --surface: #ffffff;
+      --surface-soft: #f7f7fb;
+      --surface-contrast: #1f1f2b;
+      --border: #e5e7ef;
+      --accent: #5c47ff;
+      --accent-soft: #e7e5ff;
+      --text: #201b33;
+      --text-soft: #5f5a75;
+      --radius-lg: 24px;
+      --radius-md: 16px;
+      --shadow: 0 30px 60px rgba(21, 20, 37, 0.12);
+      --shadow-soft: 0 10px 35px rgba(21, 20, 37, 0.08);
     }
 
-    * {
+    *, *::before, *::after {
       box-sizing: border-box;
     }
 
     body {
       margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(180deg, #f5f6ff 0%, #fbfbfd 100%);
+      color: var(--text);
       min-height: 100vh;
-      font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .site-wrapper {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(16px);
+      border-bottom: 1px solid rgba(94, 94, 110, 0.08);
+    }
+
+    .header-inner {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1.25rem clamp(1.5rem, 4vw, 3rem);
       display: flex;
       align-items: center;
-      justify-content: center;
-      padding: clamp(2rem, 6vw, 5rem) clamp(1.5rem, 4vw, 4rem);
-      background: radial-gradient(circle at 20% 20%, rgba(123, 78, 216, 0.18), transparent 40%),
-                  radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.08), transparent 35%),
-                  linear-gradient(130deg, var(--bg-primary), var(--bg-secondary));
-      color: white;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .brand {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .brand__title {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(1.5rem, 2.2vw, 2rem);
+      letter-spacing: -0.02em;
+    }
+
+    .brand__tagline {
+      font-size: 0.9rem;
+      color: var(--text-soft);
+    }
+
+    .main-nav {
+      display: flex;
+      gap: 1rem;
       position: relative;
-      overflow: hidden;
     }
 
-    body::before,
-    body::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-    }
-
-    body::before {
-      background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200"><g fill="none" stroke="%2342277a" stroke-width="0.6"><path d="M0 100 Q 50 80 100 100 T 200 100"/><path d="M0 120 Q 50 100 100 120 T 200 120"/><path d="M0 140 Q 50 120 100 140 T 200 140"/></g></svg>');
-      opacity: 0.18;
-      mix-blend-mode: screen;
-    }
-
-    body::after {
-      background: radial-gradient(circle at 10% 90%, rgba(200, 180, 255, 0.14), transparent 50%),
-                  radial-gradient(circle at 70% 10%, rgba(91, 52, 170, 0.22), transparent 60%);
-      opacity: 0.8;
-    }
-
-    .layout {
-      width: min(1100px, 100%);
-      display: grid;
-      gap: clamp(1.5rem, 3vw, 2.5rem);
-    }
-
-    .book {
-      position: relative;
-      border-radius: 36px;
-      background: rgba(255, 255, 255, 0.05);
-      backdrop-filter: blur(24px);
-      box-shadow: var(--shadow);
-      padding: clamp(2.8rem, 5vw, 4rem);
-      display: grid;
-      grid-template-columns: minmax(220px, 0.8fr) minmax(400px, 1fr);
-      gap: clamp(2rem, 3vw, 3.4rem);
-      overflow: hidden;
-    }
-
-    .book::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      width: clamp(80px, 14vw, 120px);
-      background: linear-gradient(145deg, rgba(35, 12, 61, 0.95), rgba(64, 27, 102, 0.7));
-      box-shadow: inset -12px 0 24px rgba(12, 0, 26, 0.25);
-      border-radius: 36px 0 0 36px;
-    }
-
-    .book__spine {
+    .nav-item {
       position: relative;
       display: flex;
       flex-direction: column;
-      gap: 1.6rem;
-      justify-content: space-between;
-      padding: 0.5rem 0;
-      color: rgba(255, 255, 255, 0.88);
-      z-index: 1;
     }
 
-    .book__title {
-      font-family: 'Playfair Display', serif;
-      font-weight: 700;
-      font-size: clamp(1.6rem, 2.6vw, 2.3rem);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      margin: 0;
-      color: var(--accent-soft);
-    }
-
-    .book__meta {
-      font-size: 0.95rem;
-      line-height: 1.6;
-      max-width: 16ch;
-      color: rgba(255, 255, 255, 0.7);
-    }
-
-    .book__bookmark {
-      position: relative;
+    .nav-button {
+      appearance: none;
+      border: none;
+      background: transparent;
+      padding: 0.4rem 0.6rem;
+      font: inherit;
+      font-weight: 500;
+      color: var(--text);
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      padding: 0.4rem 0.8rem 0.4rem 1rem;
-      background: rgba(200, 180, 255, 0.18);
       border-radius: 999px;
-      font-size: 0.75rem;
-      letter-spacing: 0.2em;
-      text-transform: uppercase;
-      font-weight: 600;
-      color: rgba(255, 255, 255, 0.82);
+      transition: background 0.2s ease, color 0.2s ease;
+      cursor: pointer;
     }
 
-    .book__bookmark::before {
-      content: "✦";
-      font-size: 0.8rem;
+    .nav-button::after {
+      content: '';
+      width: 0.45rem;
+      height: 0.45rem;
+      border-right: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(45deg);
+      margin-top: -0.25rem;
+      transition: transform 0.25s ease;
     }
 
-    .book__page {
-      position: relative;
-      background: var(--page);
-      border-radius: 28px;
-      box-shadow: inset 0 0 0 1px rgba(123, 78, 216, 0.12), inset 0 12px 25px rgba(123, 78, 216, 0.08);
-      padding: clamp(2rem, 3vw, 3rem);
-      color: var(--text-main);
-      overflow: hidden;
-    }
-
-    .book__page::before,
-    .book__page::after {
-      content: "";
-      position: absolute;
-      inset: 1.2rem;
-      border-radius: 22px;
-      pointer-events: none;
-    }
-
-    .book__page::before {
-      border: 1px solid rgba(123, 78, 216, 0.18);
-    }
-
-    .book__page::after {
-      inset: 1.2rem 1.2rem 1.6rem 1.2rem;
-      border-radius: 18px;
-      box-shadow: 0 40px 60px rgba(81, 45, 130, 0.12);
-      opacity: 0.4;
-    }
-
-    .book__page-content {
-      position: relative;
-      z-index: 1;
-    }
-
-    #content {
-      margin: 0;
-      font-size: 1rem;
-      line-height: 1.7;
-      color: inherit;
-    }
-
-    #content h1,
-    #content h2,
-    #content h3,
-    #content h4,
-    #content h5,
-    #content h6 {
-      font-family: 'Playfair Display', serif;
-      color: var(--text-main);
-      margin-top: 2.2rem;
-      margin-bottom: 1rem;
-      letter-spacing: 0.04em;
-    }
-
-    #content h1 {
-      font-size: clamp(2.1rem, 3vw, 2.6rem);
-      margin-top: 0;
-      color: #3c1b63;
-    }
-
-    #content h2 {
-      font-size: clamp(1.6rem, 2.4vw, 2rem);
-      color: #4e2777;
-    }
-
-    #content h3 {
-      font-size: clamp(1.3rem, 2vw, 1.6rem);
-      color: #563083;
-    }
-
-    #content p {
-      margin: 1.2rem 0;
-      color: var(--text-muted);
-    }
-
-    #content ul,
-    #content ol {
-      margin: 1rem 0 1.6rem 1.4rem;
-      padding: 0;
-      color: var(--text-muted);
-    }
-
-    #content li {
-      padding-left: 0.4rem;
-      margin-bottom: 0.6rem;
-    }
-
-    #content blockquote {
-      margin: 1.6rem 0;
-      padding: 1.4rem 1.6rem;
-      background: rgba(123, 78, 216, 0.12);
-      border-left: 4px solid rgba(123, 78, 216, 0.8);
-      border-radius: 12px;
-      color: #432660;
-      font-style: italic;
-    }
-
-    #content code {
-      font-family: 'IBM Plex Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
-      background: rgba(123, 78, 216, 0.18);
-      padding: 0.15rem 0.35rem;
-      border-radius: 6px;
-      color: #2b0d4d;
-      font-size: 0.95em;
-    }
-
-    #content pre {
-      background: rgba(123, 78, 216, 0.15);
-      padding: 1.2rem 1.4rem;
-      border-radius: 14px;
-      overflow-x: auto;
-      box-shadow: inset 0 0 0 1px rgba(123, 78, 216, 0.12);
-    }
-
-    #content pre code {
-      background: transparent;
-      padding: 0;
-    }
-
-    #content a {
+    .nav-item.open .nav-button {
+      background: var(--accent-soft);
       color: var(--accent);
-      text-decoration: none;
-      font-weight: 600;
-      position: relative;
-      transition: color 0.3s ease;
     }
 
-    #content a::after {
-      content: "";
+    .nav-item.open .nav-button::after {
+      transform: rotate(-135deg);
+    }
+
+    .nav-panel {
       position: absolute;
+      top: calc(100% + 0.8rem);
       left: 0;
-      bottom: -0.15rem;
-      width: 100%;
-      height: 2px;
-      background: linear-gradient(90deg, rgba(123, 78, 216, 0), rgba(123, 78, 216, 0.8), rgba(123, 78, 216, 0));
-      transform: scaleX(0);
-      transform-origin: center;
-      transition: transform 0.3s ease;
+      display: none;
+      min-width: clamp(220px, 24vw, 320px);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-soft);
+      padding: 1.2rem;
+      animation: fadeIn 0.25s ease;
     }
 
-    #content a:hover {
-      color: #5426a8;
+    .nav-item.open .nav-panel {
+      display: block;
     }
 
-    #content a:hover::after {
-      transform: scaleX(1);
+    .tree {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.6rem;
+      font-size: 0.92rem;
     }
 
-    #content table {
-      width: 100%;
-      border-collapse: collapse;
-      margin: 1.8rem 0;
+    .tree__group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .tree__label {
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .tree__link {
+      padding: 0.35rem 0.5rem;
+      border-radius: 10px;
+      color: var(--text-soft);
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .tree__link:hover {
+      background: var(--surface-soft);
+      color: var(--text);
+    }
+
+    main {
+      flex: 1;
+      padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 5vw, 3rem) 4rem;
+    }
+
+    .page-layout {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.5rem;
+    }
+
+    .hero {
+      display: grid;
+      gap: 1.8rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: stretch;
+    }
+
+    .hero-content {
+      background: var(--surface);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      padding: clamp(2rem, 4vw, 3rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1.3rem;
+    }
+
+    .hero-kicker {
+      font-size: 0.8rem;
+      letter-spacing: 0.25em;
+      text-transform: uppercase;
+      color: var(--accent);
+      font-weight: 600;
+    }
+
+    .hero-title {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      line-height: 1.15;
+      margin: 0;
+    }
+
+    .hero-description {
+      font-size: 1rem;
+      color: var(--text-soft);
+      line-height: 1.6;
+    }
+
+    .hero-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+    }
+
+    .hero-meta span {
+      background: var(--accent-soft);
+      color: var(--accent);
+      padding: 0.35rem 0.8rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+
+    .hero-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      color: var(--surface-contrast);
+    }
+
+    .hero-cta::after {
+      content: '';
+      width: 0.6rem;
+      height: 0.6rem;
+      border-right: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(-45deg);
+      transition: transform 0.25s ease;
+    }
+
+    .hero-cta:hover::after {
+      transform: translateX(2px) rotate(-45deg);
+    }
+
+    .hero-notes {
+      background: linear-gradient(160deg, rgba(92, 71, 255, 0.12), rgba(92, 71, 255, 0.05));
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(92, 71, 255, 0.12);
+      padding: clamp(1.8rem, 4vw, 2.5rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+      color: var(--surface-contrast);
+    }
+
+    .hero-notes h2 {
+      margin: 0;
+      font-size: clamp(1.4rem, 2.2vw, 1.8rem);
+    }
+
+    .hero-notes p {
+      margin: 0;
+      color: rgba(26, 25, 47, 0.75);
+      line-height: 1.6;
+    }
+
+    .hero-notes ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: grid;
+      gap: 0.35rem;
+      color: rgba(26, 25, 47, 0.8);
       font-size: 0.95rem;
     }
 
-    #content th,
-    #content td {
-      padding: 0.75rem 1rem;
-      border: 1px solid rgba(123, 78, 216, 0.16);
-      text-align: left;
-      color: var(--text-muted);
+    .sections {
+      display: grid;
+      gap: 2.4rem;
     }
 
-    #content th {
-      background: rgba(123, 78, 216, 0.12);
-      color: #3c1b63;
+    .section-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .section-header h2 {
+      margin: 0;
+      font-size: 1.3rem;
+    }
+
+    .section-header p {
+      margin: 0;
+      color: var(--text-soft);
+      font-size: 0.95rem;
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .card {
+      background: var(--surface);
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(27, 24, 45, 0.05);
+      padding: 1.6rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+      box-shadow: var(--shadow-soft);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 22px 50px rgba(21, 20, 37, 0.12);
+    }
+
+    .card__kicker {
+      font-size: 0.75rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--accent);
       font-weight: 600;
     }
 
-    #content img {
-      max-width: 100%;
-      display: block;
-      margin: 2rem auto;
-      border-radius: 16px;
-      box-shadow: 0 18px 35px rgba(60, 27, 99, 0.14);
+    .card__title {
+      font-weight: 600;
+      font-size: 1.05rem;
+      color: var(--text);
+      margin: 0;
     }
 
-    @media (max-width: 900px) {
-      body {
+    .card__description {
+      margin: 0;
+      color: var(--text-soft);
+      font-size: 0.92rem;
+      line-height: 1.6;
+    }
+
+    .card__meta {
+      margin-top: auto;
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+
+    .card__meta span {
+      background: var(--surface-soft);
+      color: var(--text-soft);
+      border-radius: 999px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .footer {
+      border-top: 1px solid rgba(27, 24, 45, 0.08);
+      background: #f4f4fb;
+    }
+
+    .footer-inner {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+      color: var(--text-soft);
+      font-size: 0.9rem;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(-4px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (max-width: 840px) {
+      .header-inner {
+        flex-direction: column;
         align-items: flex-start;
       }
 
-      .book {
-        grid-template-columns: 1fr;
-        padding: clamp(2rem, 6vw, 3rem);
-      }
-
-      .book::before {
+      .main-nav {
         width: 100%;
-        height: clamp(120px, 28vw, 180px);
-        border-radius: 36px 36px 0 0;
-        box-shadow: inset 0 -12px 24px rgba(12, 0, 26, 0.25);
+        flex-wrap: wrap;
       }
 
-      .book__spine {
-        flex-direction: row;
-        align-items: center;
-        gap: 1.4rem;
+      .nav-item {
+        flex: 1 1 calc(50% - 1rem);
       }
 
-      .book__meta {
-        max-width: none;
+      .nav-panel {
+        position: relative;
+        top: 0;
+        left: 0;
+        margin-top: 0.6rem;
+        width: 100%;
       }
     }
 
-    @media (max-width: 600px) {
-      body {
-        padding: 2rem 1.2rem 3rem;
-      }
-
-      .book {
-        padding: 1.8rem;
-        border-radius: 28px;
-      }
-
-      .book__page {
-        border-radius: 22px;
-        padding: 1.8rem;
-      }
-
-      .book__page::before,
-      .book__page::after {
-        inset: 0.9rem;
+    @media (max-width: 560px) {
+      .nav-item {
+        flex: 1 1 100%;
       }
     }
   </style>
 </head>
 <body>
-  <main class="layout" role="main">
-    <section class="book" aria-label="Whitepapers de Caio Marcatti">
-      <div class="book__spine" aria-hidden="true">
-        <span class="book__bookmark">Coleção Digital</span>
-        <div>
-          <h1 class="book__title">Whitepapers</h1>
-          <p class="book__meta">Explore as ideias, práticas e anotações de engenharia de Caio Marcatti.</p>
+  <div class="site-wrapper">
+    <header class="site-header">
+      <div class="header-inner">
+        <div class="brand">
+          <span class="brand__title">Caio Marcatti</span>
+          <span class="brand__tagline">Whitepapers, anotações e descobertas técnicas</span>
         </div>
+        <nav class="main-nav" aria-label="Verticais de conhecimento"></nav>
       </div>
-      <div class="book__page" role="article">
-        <div class="book__page-content">
-          <div id="content">Carregando...</div>
-        </div>
+    </header>
+
+    <main>
+      <div class="page-layout">
+        <section class="hero">
+          <article class="hero-content" aria-labelledby="hero-title">
+            <span class="hero-kicker">Em destaque</span>
+            <h1 class="hero-title" id="hero-title"></h1>
+            <p class="hero-description"></p>
+            <div class="hero-meta"></div>
+            <a class="hero-cta" id="hero-link" href="#" target="_blank" rel="noreferrer noopener">Ler agora</a>
+          </article>
+          <aside class="hero-notes">
+            <h2>Mapa da base</h2>
+            <p>Um hub único para meus principais estudos e materiais de referência. Explore os artigos por vertical e aprofunde-se nas trilhas que uso no dia a dia.</p>
+            <ul>
+              <li>Trilhas com tópicos encadeados</li>
+              <li>Artigos práticos e de governança</li>
+              <li>Referências rápidas para consultas</li>
+            </ul>
+          </aside>
+        </section>
+
+        <section class="sections" aria-label="Conteúdo recente e trilhas">
+          <div class="section" id="recent-section">
+            <div class="section-header">
+              <h2>Últimos artigos publicados</h2>
+              <p>Insights recentes sobre containers, segurança e engenharia de software.</p>
+            </div>
+            <div class="card-grid" id="recent-articles"></div>
+          </div>
+
+          <div class="section">
+            <div class="section-header">
+              <h2>Explorar trilhas</h2>
+              <p>Escolha uma vertical e siga o caminho recomendado para estudar.</p>
+            </div>
+            <div class="card-grid" id="deep-dives"></div>
+          </div>
+        </section>
       </div>
-    </section>
-  </main>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-inner">
+        <span>Construído para organizar aprendizados e frameworks pessoais.</span>
+        <span>© <span id="year"></span> Caio Marcatti. Mantido como um projeto vivo.</span>
+      </div>
+    </footer>
+  </div>
 
   <script>
-    const md = window.markdownit({ html: true });
-
-    async function loadMarkdown(file) {
-      try {
-        const response = await fetch(file);
-        if (!response.ok) throw new Error("Arquivo não encontrado: " + file);
-        const text = await response.text();
-        document.getElementById("content").innerHTML = md.render(text);
-        setupLinks();
-      } catch (err) {
-        document.getElementById("content").innerHTML = `<p style="color:crimson">${err.message}</p>`;
+    const navigation = [
+      {
+        title: 'Containers',
+        description: 'Boas práticas para imagens e deploys consistentes',
+        items: [
+          {
+            label: 'A Importância de Fixar a Versão da Instalação dos Pacotes em um Container Docker',
+            href: 'container/fix-version/fix-version.md',
+            summary: 'Como garantir reprodutibilidade e evitar surpresas em imagens Docker.'
+          }
+        ]
+      },
+      {
+        title: 'Segurança em Software',
+        description: 'Supply chain e proteção de aplicações modernas',
+        items: [
+          {
+            label: 'A Importância da Cadeia de Suprimentos na Proteção do Seu Código',
+            href: 'security/intro-supply-chain/intro-supply-chain.md',
+            summary: 'Estratégias para proteger dependências e pipelines do seu software.'
+          }
+        ]
+      },
+      {
+        title: 'Linguagens',
+        description: 'Notas práticas sobre stacks que utilizo',
+        items: [
+          {
+            title: 'Go',
+            items: [
+              {
+                label: '`go get` em repositórios privados',
+                href: 'languages/go/go-get-private-repo.md',
+                summary: 'Como autenticar com SSH e evitar problemas em builds privados.'
+              }
+            ]
+          }
+        ]
+      },
+      {
+        title: 'Clean Code',
+        description: 'Fundamentos que norteiam meu processo de desenvolvimento',
+        items: [
+          { label: 'Introdução', href: 'clean-code/1-introduction.md' },
+          { label: 'O que é Clean Code', href: 'clean-code/1.1-clean-code.md' },
+          { label: 'O Custo de um Código Ruim', href: 'clean-code/1.3-cost.md' },
+          { label: 'A Grande Reescrita', href: 'clean-code/1.4-the-great-redesign.md' }
+        ]
       }
+    ];
+
+    const hero = {
+      title: 'Fortalecendo a cadeia de suprimentos do seu software',
+      description: 'Um guia direto ao ponto para entender os riscos de supply chain, estruturar controles e criar checkpoints que blindam seu código em ambientes modernos.',
+      href: 'security/intro-supply-chain/intro-supply-chain.md',
+      tags: ['Segurança', 'Estratégia', 'Governança']
+    };
+
+    const recentArticles = [
+      {
+        kicker: 'Containers',
+        title: 'Fixar versões em Docker para evitar dor de cabeça',
+        description: 'A prática de versionar instalações garante builds determinísticos, previsíveis e seguros.',
+        href: 'container/fix-version/fix-version.md',
+        meta: ['Checklist', 'DevOps']
+      },
+      {
+        kicker: 'Segurança',
+        title: 'Protegendo a cadeia de suprimentos',
+        description: 'Como abordar dependências de terceiros sem perder de vista a segurança do pipeline.',
+        href: 'security/intro-supply-chain/intro-supply-chain.md',
+        meta: ['Supply Chain', 'Gestão de risco']
+      },
+      {
+        kicker: 'Go',
+        title: 'Autenticando `go get` em repositórios privados',
+        description: 'Estratégias para manter o fluxo de desenvolvimento sem expor credenciais.',
+        href: 'languages/go/go-get-private-repo.md',
+        meta: ['Linguagens', 'Automação']
+      }
+    ];
+
+    function getFirstHref(items = []) {
+      for (const item of items) {
+        if (item.href) {
+          return item.href;
+        }
+        if (item.items) {
+          const nestedHref = getFirstHref(item.items);
+          if (nestedHref) {
+            return nestedHref;
+          }
+        }
+      }
+      return '#';
     }
 
-    function setupLinks() {
-      document.querySelectorAll("#content a").forEach(link => {
-        link.addEventListener("click", ev => {
-          const href = link.getAttribute("href");
-          if (href && href.endsWith(".md")) {
-            ev.preventDefault();
-            loadMarkdown(href);
-            history.pushState({ file: href }, "", href.replace(".md", ".html"));
+    function countLeafs(items = []) {
+      return items.reduce((total, item) => {
+        if (item.items) {
+          return total + countLeafs(item.items);
+        }
+        return total + 1;
+      }, 0);
+    }
+
+    const deepDives = navigation.map((section) => ({
+      title: section.title,
+      description: section.description,
+      href: getFirstHref(section.items),
+      meta: `${countLeafs(section.items)} materiais`
+    }));
+
+    const navContainer = document.querySelector('.main-nav');
+
+    function createTree(nodes) {
+      const list = document.createElement('ul');
+      list.className = 'tree';
+
+      nodes.forEach((node) => {
+        if (node.items) {
+          const group = document.createElement('li');
+          group.className = 'tree__group';
+
+          const label = document.createElement('span');
+          label.className = 'tree__label';
+          label.textContent = node.title || node.label;
+          group.appendChild(label);
+
+          const nested = createTree(node.items);
+          nested.style.paddingLeft = '0.8rem';
+          group.appendChild(nested);
+
+          list.appendChild(group);
+        } else {
+          const item = document.createElement('li');
+          const link = document.createElement('a');
+          link.className = 'tree__link';
+          link.href = node.href;
+          link.textContent = node.label;
+          link.target = '_blank';
+          link.rel = 'noreferrer noopener';
+          item.appendChild(link);
+          list.appendChild(item);
+        }
+      });
+
+      return list;
+    }
+
+    navigation.forEach((section) => {
+      const item = document.createElement('div');
+      item.className = 'nav-item';
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'nav-button';
+      button.textContent = section.title;
+      item.appendChild(button);
+
+      const panel = document.createElement('div');
+      panel.className = 'nav-panel';
+      panel.appendChild(createTree(section.items));
+      item.appendChild(panel);
+
+      button.addEventListener('click', () => {
+        const wasOpen = item.classList.contains('open');
+        document.querySelectorAll('.nav-item.open').forEach((openItem) => {
+          if (openItem !== item) {
+            openItem.classList.remove('open');
           }
         });
+        item.classList.toggle('open', !wasOpen);
       });
-    }
 
-    window.addEventListener("popstate", ev => {
-      if (ev.state && ev.state.file) {
-        loadMarkdown(ev.state.file);
-      } else {
-        loadMarkdown("index.md");
+      navContainer.appendChild(item);
+    });
+
+    document.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!target.closest('.nav-item')) {
+        document.querySelectorAll('.nav-item.open').forEach((openItem) => openItem.classList.remove('open'));
       }
     });
 
-    loadMarkdown("index.md");
+    document.getElementById('hero-title').textContent = hero.title;
+    document.querySelector('.hero-description').textContent = hero.description;
+    const heroMeta = document.querySelector('.hero-meta');
+    hero.tags.forEach((tag) => {
+      const badge = document.createElement('span');
+      badge.textContent = tag;
+      heroMeta.appendChild(badge);
+    });
+    document.getElementById('hero-link').href = hero.href;
+
+    const recentContainer = document.getElementById('recent-articles');
+    recentArticles.forEach((article) => {
+      const card = document.createElement('a');
+      card.className = 'card';
+      card.href = article.href;
+      card.target = '_blank';
+      card.rel = 'noreferrer noopener';
+
+      const kicker = document.createElement('span');
+      kicker.className = 'card__kicker';
+      kicker.textContent = article.kicker;
+      card.appendChild(kicker);
+
+      const title = document.createElement('h3');
+      title.className = 'card__title';
+      title.textContent = article.title;
+      card.appendChild(title);
+
+      const description = document.createElement('p');
+      description.className = 'card__description';
+      description.textContent = article.description;
+      card.appendChild(description);
+
+      const meta = document.createElement('div');
+      meta.className = 'card__meta';
+      article.meta.forEach((tag) => {
+        const badge = document.createElement('span');
+        badge.textContent = tag;
+        meta.appendChild(badge);
+      });
+      card.appendChild(meta);
+
+      recentContainer.appendChild(card);
+    });
+
+    const deepDiveContainer = document.getElementById('deep-dives');
+    deepDives.forEach((trail) => {
+      const card = document.createElement('a');
+      card.className = 'card';
+      card.href = trail.href;
+      card.target = '_blank';
+      card.rel = 'noreferrer noopener';
+
+      const kicker = document.createElement('span');
+      kicker.className = 'card__kicker';
+      kicker.textContent = 'Trilha';
+      card.appendChild(kicker);
+
+      const title = document.createElement('h3');
+      title.className = 'card__title';
+      title.textContent = trail.title;
+      card.appendChild(title);
+
+      const description = document.createElement('p');
+      description.className = 'card__description';
+      description.textContent = trail.description;
+      card.appendChild(description);
+
+      const meta = document.createElement('div');
+      meta.className = 'card__meta';
+      const badge = document.createElement('span');
+      badge.textContent = trail.meta;
+      meta.appendChild(badge);
+      card.appendChild(meta);
+
+      deepDiveContainer.appendChild(card);
+    });
+
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the homepage with a clean blog-style layout and typography refresh
- add an expandable top navigation menu that exposes content trees for each knowledge area
- highlight featured, recent, and deep-dive articles with card-based sections

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d989fb3d588327a4978a8daaa956cb